### PR TITLE
add shebang to launcher.sh

### DIFF
--- a/launcher.sh
+++ b/launcher.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 cd src/
 python3 "__main__.py"


### PR DESCRIPTION
usually unnecessary, but it's best practice to include a shebang on shell scripts