### PR TITLE
Handle Spiget api errors, use best-practice, disable incompatible code

### DIFF
--- a/install_requirements.py
+++ b/install_requirements.py
@@ -8,6 +8,6 @@ try:
     print("Installing Python packages and dependencies from requirements.txt...\n")
     os.system('py -m pip install -r requirements.txt' if os.name=='nt' else 'pip install -r requirements.txt')
     print("\nStart pluGET by launching the 'pluGET.py' file!")
-except:
-    print("Requirements couldn't be installed. Check if file 'requirements.txt' is in the same folder and that Python3\
+except Exception as e:
+    print(f"Requirements couldn't be installed.\nError message: {e}\n\nCommon solution: Check if file 'requirements.txt' is in the same folder and that Python3\
          and pip is installed!")

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -6,7 +6,7 @@ import os
 
 try:
     print("Installing Python packages and dependencies from requirements.txt...\n")
-    os.system('py -m pip install -r requirements.txt' if os.name=='nt' else 'pip install -r requirements.txt')
+    os.system('py -m pip install -r requirements.txt' if os.name=='nt' else 'python3 -m pip install -r requirements.txt')
     print("\nStart pluGET by launching the 'pluGET.py' file!")
 except Exception as e:
     print(f"Requirements couldn't be installed.\nError message: {e}\n\nCommon solution: Check if file 'requirements.txt' is in the same folder and that Python3\

--- a/src/plugin/plugin_updatechecker.py
+++ b/src/plugin/plugin_updatechecker.py
@@ -520,11 +520,16 @@ def search_plugin_spiget(plugin_file: str, plugin_file_name: str, plugin_file_ve
     """
     url = f"https://api.spiget.org/v2/search/resources/{plugin_file_name}?field=name&sort=-downloads"
     plugin_list = api_do_request(url)
-    
+
     # Handle failed api request
-    """{'error': 'Unexpected Exception', 'msg': 'Unexpected Exception. Please report this to https://github.com/SpiGetOrg/api.spiget.org/issues'}"""
+    """
+    {'error': 'Unexpected Exception', 'msg': 'Unexpected Exception. Please report this to 
+    https://github.com/SpiGetOrg/api.spiget.org/issues'}
+    """
     if "error" in plugin_list:
-        print(f"Spiget error occurred whilst searching for plugin '{plugin_file}': {plugin_list['msg']}")
+        rich_print_error(
+            f"[not bold]Error: Spiget error occurred whilst searching for plugin '{plugin_file}': {plugin_list['msg']}"
+        )
         return plugin_list['msg']
     else:
         plugin_file_version2 = plugin_file_version

--- a/src/plugin/plugin_updatechecker.py
+++ b/src/plugin/plugin_updatechecker.py
@@ -520,49 +520,56 @@ def search_plugin_spiget(plugin_file: str, plugin_file_name: str, plugin_file_ve
     """
     url = f"https://api.spiget.org/v2/search/resources/{plugin_file_name}?field=name&sort=-downloads"
     plugin_list = api_do_request(url)
-    plugin_file_version2 = plugin_file_version
-    for i in range(4):
-        if i == 1:
-            plugin_file_version2 = re.sub(r'(\-\w*)', '', plugin_file_version)
-        if i == 2:
-            plugin_name_in_yml, plugin_version_in_yml = egg_cracking_jar(plugin_file)
-            url = f"https://api.spiget.org/v2/search/resources/{plugin_name_in_yml}?field=name&sort=-downloads"
-            try:
-                plugin_list = api_do_request(url)
-            except ValueError:
-                continue
-            # if no plugin name was found with egg_cracking_jar() skip this round
-            if plugin_list is None:
-                continue
+    
+    # Handle failed api request
+    """{'error': 'Unexpected Exception', 'msg': 'Unexpected Exception. Please report this to https://github.com/SpiGetOrg/api.spiget.org/issues'}"""
+    if "error" in plugin_list:
+        print(f"Spiget error occurred whilst searching for plugin '{plugin_file}': {plugin_list['msg']}")
+        return plugin_list['msg']
+    else:
+        plugin_file_version2 = plugin_file_version
+        for i in range(4):
+            if i == 1:
+                plugin_file_version2 = re.sub(r'(\-\w*)', '', plugin_file_version)
+            if i == 2:
+                plugin_name_in_yml, plugin_version_in_yml = egg_cracking_jar(plugin_file)
+                url = f"https://api.spiget.org/v2/search/resources/{plugin_name_in_yml}?field=name&sort=-downloads"
+                try:
+                    plugin_list = api_do_request(url)
+                except ValueError:
+                    continue
+                # if no plugin name was found with egg_cracking_jar() skip this round
+                if plugin_list is None:
+                    continue
 
-        # search with version which is in plugin.yml for the plugin
-        if i == 3:
-            plugin_file_version2 = plugin_version_in_yml
+            # search with version which is in plugin.yml for the plugin
+            if i == 3:
+                plugin_file_version2 = plugin_version_in_yml
 
 
-        for plugin in plugin_list:
-            plugin_id = plugin["id"]
-            url2 = f"https://api.spiget.org/v2/resources/{plugin_id}/versions?size=100&sort=-name"
-            try:
-                plugin_versions = api_do_request(url2)
-            except ValueError:
-                continue
-            if plugin_versions is None:
-                continue
-            for updates in plugin_versions:
-                update_version_name = updates["name"]
-                if plugin_file_version2 in update_version_name:
-                    #spigot_update_id = updates["id"]
-                    plugin_latest_version = get_latest_plugin_version_spiget(plugin_id)
-                    plugin_is_outdated = compare_plugin_version(plugin_latest_version, update_version_name)
-                    Plugin.add_to_plugin_list(
-                        plugin_file,
-                        plugin_file_name,
-                        plugin_file_version,
-                        plugin_latest_version,
-                        plugin_is_outdated,
-                        "spigot",
-                        [plugin_id]
-                    )
-                    return plugin_id
-    return None
+            for plugin in plugin_list:
+                plugin_id = plugin["id"]
+                url2 = f"https://api.spiget.org/v2/resources/{plugin_id}/versions?size=100&sort=-name"
+                try:
+                    plugin_versions = api_do_request(url2)
+                except ValueError:
+                    continue
+                if plugin_versions is None:
+                    continue
+                for updates in plugin_versions:
+                    update_version_name = updates["name"]
+                    if plugin_file_version2 in update_version_name:
+                        #spigot_update_id = updates["id"]
+                        plugin_latest_version = get_latest_plugin_version_spiget(plugin_id)
+                        plugin_is_outdated = compare_plugin_version(plugin_latest_version, update_version_name)
+                        Plugin.add_to_plugin_list(
+                            plugin_file,
+                            plugin_file_name,
+                            plugin_file_version,
+                            plugin_latest_version,
+                            plugin_is_outdated,
+                            "spigot",
+                            [plugin_id]
+                        )
+                        return plugin_id
+        return None

--- a/src/utils/console_output.py
+++ b/src/utils/console_output.py
@@ -21,7 +21,8 @@ def rename_console_title() -> None:
     """
     Renames the console title on first startup
     """
-    os.system("title " + "pluGET │ By Neocky")
+    if os.name == "nt":
+        os.system("title " + "pluGET │ By Neocky")
     return None
 
 


### PR DESCRIPTION
## Changes

### `install_requirements.py`
- Use `python3 -m pip` instead of `pip` when installing on posix operating systems, as documented [here](https://packaging.python.org/en/latest/tutorials/installing-packages/#requirements-files).
- If an exception occurs, display the exception detail to the user alongside the troubleshooting suggestion.

### `src/plugin/plugin_updatechecker.py`
- Handle Spiget api request errors, instead of crashing due to erroneously handling the unexpected data structure: [`{'error': '', 'msg': ''}`](https://api.spiget.org/v2/search/resources/InvSee++.jar?field=name&sort=-downloads). Further detail can be found in the [commit description](https://github.com/Neocky/pluGET/commit/18ca3104a51be33b27c6d54d7da11f5230a118a2).

### `src/utils/console_output.py`
- Don't attempt to change the console title on non-Windows systems to prevent an unexpected command error message from being displayed.