### PR TITLE
Added Modrinth + Github Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ A powerful package manager which updates [Plugins](https://www.spigotmc.org/reso
 </details>
 
 ## 💡 About  
-pluGET is a standalone package manager written in python for minecraft [Spigot](https://www.spigotmc.org/) servers and its forks (e.g. [PaperMC](https://papermc.io/)). The program works with a locally installed servers or with a remote host through SFTP/FTP, when configured in the config. It uses the [Spiget](https://spiget.org/) API to download and compare plugin versions and download the latest version of plugins from the [Spigot](https://www.spigotmc.org/) site. It can also compare and download the latest update of specific server software (e.g. [PaperMC](https://papermc.io/)).
+pluGET is a standalone package manager written in python for minecraft [Spigot](https://www.spigotmc.org/) servers and its forks (e.g. [PaperMC](https://papermc.io/)). The program works with a locally installed servers or with a remote host through SFTP/FTP, when configured in the config. It uses multiple APIs to download and compare plugin versions from [Spigot](https://www.spigotmc.org/), [Modrinth](https://modrinth.com/), and [GitHub](https://github.com/) repositories. It can also compare and download the latest update of specific server software (e.g. [PaperMC](https://papermc.io/)).
 
 Plugin management is the hard part of managing a minecraft server. The time it takes to manually check the [Spigot resources](https://www.spigotmc.org/resources/) page for updates and manually downloading all plugins is too long and daunting. So I built pluGET to automate and ease the plugin handling of a minecraft server and to turn the most time consuming part of managing a minecraft server to an easy one.
 
@@ -52,6 +52,10 @@ This program is suited for minecraft server owners who want to save time and sta
 - Works locally or through SFTP/FTP
 - Runs directly from the console with command line arguments
 - Checks for updates and downloads the latest version of all/specific plugins
+- **Multi-platform plugin support:**
+  - [Spigot](https://www.spigotmc.org/) (via Spiget API)
+  - [Modrinth](https://modrinth.com/) (with accurate file hash matching)
+  - [GitHub](https://github.com/) releases (with name matching)
 - Checks for updates and downloads the latest version of your server software
   - [PaperMc](https://papermc.io/)
   - [Purpur](https://purpurmc.org/)
@@ -154,6 +158,26 @@ remove [pluginID/pluginName]
 #### • Search for a plugin:  
 ```
 search [pluginName]
+```
+
+#### • Download plugin from GitHub releases:  
+```
+get-github [owner/repo]
+```
+
+#### • Download plugin from Modrinth:  
+```
+get-modrinth [project-id]
+```
+
+#### • Search for plugins on GitHub:  
+```
+search-github [searchTerm]
+```
+
+#### • Search for plugins on Modrinth:  
+```
+search-modrinth [searchTerm]
 ```
 
 ### Manage Server Software

--- a/src/handlers/handle_input.py
+++ b/src/handlers/handle_input.py
@@ -6,6 +6,8 @@ from src.utils.console_output import rich_print_error
 from src.utils.utilities import get_command_help
 from src.plugin.plugin_remover import delete_plugin
 from src.plugin.plugin_downloader import get_specific_plugin_spiget, search_specific_plugin_spiget
+from src.platforms.github_handler import download_github_plugin, search_github_plugin
+from src.platforms.modrinth_handler import download_modrinth_plugin, search_modrinth_plugin
 from src.plugin.plugin_updatechecker import check_installed_plugins, update_installed_plugins
 from src.serverjar.serverjar_updatechecker import \
     check_update_available_installed_server_jar, update_installed_server_jar
@@ -20,9 +22,13 @@ from src.serverjar.serverjar_purpur import serverjar_purpur_update
 # get-waterfall
 # get-velocity
 # get-purpur
+# get-github
+# get-modrinth
 # exit
 # remove
 # search
+# search-github
+# search-modrinth
 # help
 
 
@@ -70,6 +76,21 @@ def handle_input(
             case "get-purpur":
                 serverjar_purpur_update(input_selected_object, input_parameter, None)
 
+            case "get-github":
+                # Format: get-github owner/repo [plugin-name]
+                if input_selected_object is None:
+                    rich_print_error("Error: GitHub repository required! Format: owner/repo")
+                    continue
+                download_github_plugin(input_selected_object, input_parameter)
+                
+            case "get-modrinth":
+                # Format: get-modrinth project-id [featured-only]
+                if input_selected_object is None:
+                    rich_print_error("Error: Modrinth project ID required!")
+                    continue
+                featured_only = input_parameter == "featured" if input_parameter else False
+                download_modrinth_plugin(input_selected_object, featured_only)
+
             case "update":
                 match input_selected_object:
                     case "serverjar":
@@ -86,6 +107,21 @@ def handle_input(
 
             case "search":
                 search_specific_plugin_spiget(input_selected_object)
+            
+            case "search-github":
+                # Format: search-github search-term
+                if input_selected_object is None:
+                    rich_print_error("Error: Search term required!")
+                    continue
+                search_github_plugin(input_selected_object)
+                
+            case "search-modrinth":
+                # Format: search-modrinth search-term
+                if input_selected_object is None:
+                    rich_print_error("Error: Search term required!")
+                    continue
+                search_modrinth_plugin(input_selected_object)
+                
             case "remove":
                 delete_plugin(input_selected_object)
             case "help":

--- a/src/platforms/github_handler.py
+++ b/src/platforms/github_handler.py
@@ -5,7 +5,7 @@ Handles GitHub plugin checking, downloading and updating
 import re
 from pathlib import Path
 
-from src.utils.utilities import api_do_request
+from src.utils.utilities import api_do_request, create_temp_plugin_folder, remove_temp_plugin_folder
 from src.utils.console_output import rich_print_error
 from src.plugin.plugin_downloader import get_download_path, download_specific_plugin_version_spiget
 from src.handlers.handle_config import config_value
@@ -107,9 +107,12 @@ def download_github_plugin(github_repo: str, plugin_name: str = None) -> None:
     version = get_github_plugin_version(github_repo)
     if version is None:
         version = "latest"
-    
-    # Create download path similar to spiget implementation
-    download_path = get_download_path(config_values)
+
+    # Create download path with proper SFTP/FTP handling
+    if config_values.connection != "local":
+        download_path = create_temp_plugin_folder()
+    else:
+        download_path = get_download_path(config_values)
     plugin_download_name = f"{plugin_name}-{version}.jar"
     download_plugin_path = Path(f"{download_path}/{plugin_download_name}")
     
@@ -173,12 +176,24 @@ def _download_github_file(url: str, download_path: Path) -> None:
         console.print("    [not bold][bright_green]Downloaded[bright_magenta] " + (str(file_size_data)).rjust(9) + \
              f" KB [cyan]→ [white]{download_path}")
 
-    # check if plugin file is a proper .jar-file (try to open plugin.yml file)
-    # same validation as existing spiget implementation
+    # check if plugin file is a proper .jar-file (try to open plugin.yml or paper-plugin.yml file)
+    # updated validation to support both plugin.yml and paper-plugin.yml
+    plugin_valid = False
     try:
         with ZipFile(download_path, "r") as plugin_jar:
-            plugin_jar.open("plugin.yml", "r")
+            try:
+                plugin_jar.open("plugin.yml", "r")
+                plugin_valid = True
+            except KeyError:
+                try:
+                    plugin_jar.open("paper-plugin.yml", "r")
+                    plugin_valid = True
+                except KeyError:
+                    pass
     except:
+        pass
+    
+    if not plugin_valid:
         rich_print_error("Error: Downloaded plugin file was not a proper jar-file!")
         rich_print_error("Removing file...")
         os.remove(download_path)
@@ -191,6 +206,10 @@ def _download_github_file(url: str, download_path: Path) -> None:
     elif config_values.connection == "ftp":
         ftp_session = ftp_create_connection()
         ftp_upload_file(ftp_session, download_path)
+
+    # remove temp plugin folder if plugin was downloaded from sftp/ftp server
+    if config_values.connection != "local":
+        remove_temp_plugin_folder()
 
     return None
 

--- a/src/platforms/github_handler.py
+++ b/src/platforms/github_handler.py
@@ -1,0 +1,268 @@
+"""
+Handles GitHub plugin checking, downloading and updating
+"""
+
+import re
+from pathlib import Path
+
+from src.utils.utilities import api_do_request
+from src.utils.console_output import rich_print_error
+from src.plugin.plugin_downloader import get_download_path, download_specific_plugin_version_spiget
+from src.handlers.handle_config import config_value
+
+
+def get_github_repo_from_plugin_name(plugin_name: str) -> str:
+    """
+    Tries to guess GitHub repository from plugin name
+    This is a fallback function - ideally users should provide the full repo path
+    
+    :param plugin_name: Name of the plugin
+    :returns: Guessed repository path or None if not found
+    """
+    # This is a basic implementation - could be enhanced with a mapping file
+    # For now, return None to encourage explicit repo specification
+    return None
+
+
+def get_latest_github_release(github_repo: str) -> dict:
+    """
+    Gets the latest GitHub release information
+    
+    :param github_repo: Repository path in format 'owner/repo'
+    :returns: Release information dict or None if failed
+    """
+    url = f"https://api.github.com/repos/{github_repo}/releases/latest"
+    release_data = api_do_request(url)
+    
+    if release_data is None:
+        return None
+    
+    if "message" in release_data and release_data["message"] == "Not Found":
+        rich_print_error(f"Error: GitHub repository '{github_repo}' not found!")
+        return None
+        
+    return release_data
+
+
+def get_github_plugin_version(github_repo: str) -> str:
+    """
+    Gets the latest plugin version from GitHub releases
+    
+    :param github_repo: Repository path in format 'owner/repo'
+    :returns: Latest version string or None if failed
+    """
+    release_data = get_latest_github_release(github_repo)
+    if release_data is None:
+        return None
+        
+    version = release_data.get("tag_name", "")
+    # Remove 'v' prefix if present (e.g., 'v1.0.0' -> '1.0.0')
+    version = re.sub(r'^v', '', version)
+    return version
+
+
+def get_github_download_url(github_repo: str) -> str:
+    """
+    Gets the download URL for the latest GitHub release
+    
+    :param github_repo: Repository path in format 'owner/repo'
+    :returns: Download URL or None if failed
+    """
+    release_data = get_latest_github_release(github_repo)
+    if release_data is None:
+        return None
+        
+    assets = release_data.get("assets", [])
+    if not assets:
+        rich_print_error(f"Error: No assets found in latest release for '{github_repo}'!")
+        return None
+    
+    # Look for .jar file first
+    for asset in assets:
+        if asset["name"].endswith(".jar"):
+            return asset["browser_download_url"]
+    
+    # If no .jar found, return first asset
+    return assets[0]["browser_download_url"]
+
+
+def download_github_plugin(github_repo: str, plugin_name: str = None) -> None:
+    """
+    Downloads the latest plugin version from GitHub releases
+    
+    :param github_repo: Repository path in format 'owner/repo'
+    :param plugin_name: Optional plugin name override
+    :returns: None
+    """
+    config_values = config_value()
+    download_url = get_github_download_url(github_repo)
+    
+    if download_url is None:
+        return None
+    
+    # Extract plugin name from repo if not provided
+    if plugin_name is None:
+        plugin_name = github_repo.split('/')[-1]
+    
+    version = get_github_plugin_version(github_repo)
+    if version is None:
+        version = "latest"
+    
+    # Create download path similar to spiget implementation
+    download_path = get_download_path(config_values)
+    plugin_download_name = f"{plugin_name}-{version}.jar"
+    download_plugin_path = Path(f"{download_path}/{plugin_download_name}")
+    
+    # Use existing download infrastructure but with GitHub URL
+    _download_github_file(download_url, download_plugin_path)
+    
+    return None
+
+
+def _download_github_file(url: str, download_path: Path) -> None:
+    """
+    Downloads a file from GitHub releases - similar to download_specific_plugin_version_spiget
+    
+    :param url: GitHub asset download URL  
+    :param download_path: Path where to save the file
+    :returns: None
+    """
+    import os
+    import requests
+    from zipfile import ZipFile
+    from rich.console import Console
+    from rich.progress import Progress
+    from src.utils.utilities import convert_file_size_down
+    from src.handlers.handle_sftp import sftp_create_connection, sftp_upload_file
+    from src.handlers.handle_ftp import ftp_create_connection, ftp_upload_file
+    
+    config_values = config_value()
+    
+    # Use rich Progress() to create progress bar (same as spiget implementation)
+    with Progress(transient=True) as progress:
+        header = {'user-agent': 'pluGET/1.0'}
+        r = requests.get(url, headers=header, stream=True)
+        try:
+            file_size = int(r.headers.get('content-length'))
+            # create progress bar
+            download_task = progress.add_task("    [cyan]Downloading...", total=file_size)
+        except TypeError:
+            # Content-length returned nothing
+            file_size = 0
+        with open(download_path, 'wb') as f:
+            # split downloaded data in chunks of 32768
+            for data in r.iter_content(chunk_size=32768):
+                f.write(data)
+                # don't show progress bar if no content-length was returned
+                if file_size == 0:
+                    continue
+                progress.update(download_task, advance=len(data))
+
+    # use rich console for nice colors (same style as existing code)
+    console = Console()
+    if file_size == 0:
+        console.print(
+            f"    [not bold][bright_green]Downloaded[bright_magenta]         file [cyan]→ [white]{download_path}"
+        )
+    elif file_size >= 1000000:
+        file_size_data = convert_file_size_down(convert_file_size_down(file_size))
+        console.print("    [not bold][bright_green]Downloaded[bright_magenta] " + (str(file_size_data)).rjust(9) + \
+             f" MB [cyan]→ [white]{download_path}")
+    else:
+        file_size_data = convert_file_size_down(file_size)
+        console.print("    [not bold][bright_green]Downloaded[bright_magenta] " + (str(file_size_data)).rjust(9) + \
+             f" KB [cyan]→ [white]{download_path}")
+
+    # check if plugin file is a proper .jar-file (try to open plugin.yml file)
+    # same validation as existing spiget implementation
+    try:
+        with ZipFile(download_path, "r") as plugin_jar:
+            plugin_jar.open("plugin.yml", "r")
+    except:
+        rich_print_error("Error: Downloaded plugin file was not a proper jar-file!")
+        rich_print_error("Removing file...")
+        os.remove(download_path)
+        return None
+
+    # Handle SFTP/FTP upload same as existing implementation
+    if config_values.connection == "sftp":
+        sftp_session = sftp_create_connection()
+        sftp_upload_file(sftp_session, download_path)
+    elif config_values.connection == "ftp":
+        ftp_session = ftp_create_connection()
+        ftp_upload_file(ftp_session, download_path)
+
+    return None
+
+
+def search_github_plugin(search_term: str) -> None:
+    """
+    Search for plugins on GitHub (basic implementation)
+    GitHub doesn't have a plugin-specific search, so this searches for Java repositories
+    
+    :param search_term: Search query
+    :returns: None
+    """
+    from rich.table import Table
+    from rich.console import Console
+    
+    url = f"https://api.github.com/search/repositories?q={search_term}+language:java+spigot&sort=stars&order=desc"
+    search_results = api_do_request(url)
+    
+    if search_results is None:
+        rich_print_error("Error: GitHub search request failed!")
+        return None
+    
+    if search_results.get("total_count", 0) == 0:
+        rich_print_error(f"No repositories found for '{search_term}'")
+        return None
+    
+    repositories = search_results.get("items", [])[:10]  # Limit to top 10
+    
+    print(f"Searching GitHub for '{search_term}'...")
+    print(f"Found repositories:")
+    
+    # Create table with rich (same style as existing search)
+    rich_table = Table(box=None)
+    rich_table.add_column("No.", justify="right", style="cyan", no_wrap=True)
+    rich_table.add_column("Repository", style="bright_magenta")
+    rich_table.add_column("Stars", justify="right", style="bright_green") 
+    rich_table.add_column("Description", justify="left", style="white")
+    
+    # Start counting at 1 for consistency with existing code
+    i = 1
+    for repo in repositories:
+        repo_name = repo["full_name"]
+        stars = repo["stargazers_count"]
+        description = repo.get("description", "No description") or "No description"
+        # Truncate long descriptions
+        if len(description) > 50:
+            description = description[:47] + "..."
+        rich_table.add_row(str(i), repo_name, str(stars), description)
+        i += 1
+
+    # Print table from rich
+    rich_console = Console()
+    rich_console.print(rich_table)
+
+    try:
+        plugin_selected = input("Select your wanted repository (No.)(0 to exit): ")
+    except KeyboardInterrupt:
+        return None
+    if plugin_selected == "0":
+        return None
+    try:
+        plugin_selected = int(plugin_selected) - 1
+        selected_repo = repositories[plugin_selected]["full_name"]
+    except ValueError:
+        rich_print_error("Error: Input wasn't a number! Please try again!")
+        return None
+    except IndexError:
+        rich_print_error("Error: Number was out of range! Please try again!")
+        return None
+        
+    selected_repo_name = selected_repo.split('/')[-1]
+    rich_console.print(f"\n [not bold][bright_white]● [bright_magenta]{selected_repo_name} [bright_green]latest")
+    download_github_plugin(selected_repo, selected_repo_name)
+
+    return None

--- a/src/platforms/modrinth_handler.py
+++ b/src/platforms/modrinth_handler.py
@@ -1,0 +1,358 @@
+"""
+Handles Modrinth plugin checking, downloading and updating
+"""
+
+import re
+from pathlib import Path
+
+from src.utils.utilities import api_do_request
+from src.utils.console_output import rich_print_error
+from src.plugin.plugin_downloader import get_download_path
+from src.handlers.handle_config import config_value
+
+
+def get_modrinth_project_info(project_id: str) -> dict:
+    """
+    Gets project information from Modrinth API
+    
+    :param project_id: Modrinth project ID or slug
+    :returns: Project information dict or None if failed
+    """
+    url = f"https://api.modrinth.com/v2/project/{project_id}"
+    project_data = api_do_request(url)
+    
+    if project_data is None:
+        return None
+    
+    if "error" in project_data:
+        rich_print_error(f"Error: Modrinth project '{project_id}' not found!")
+        return None
+        
+    return project_data
+
+
+def get_modrinth_versions(project_id: str, featured_only: bool = False, version_type: str = None) -> list:
+    """
+    Gets available versions for a Modrinth project
+    
+    :param project_id: Modrinth project ID or slug
+    :param featured_only: Only return featured versions
+    :param version_type: Filter by version type (release, beta, alpha)
+    :returns: List of versions or None if failed
+    """
+    url = f"https://api.modrinth.com/v2/project/{project_id}/version"
+    
+    # Add query parameters like PluginUpdater does
+    params = []
+    params.append("loaders=[%22bukkit%22,%22spigot%22,%22paper%22,%22purpur%22,%22folia%22]")
+    
+    if featured_only:
+        params.append("featured=true")
+    
+    if version_type:
+        params.append(f"version_type={version_type}")
+    
+    if params:
+        url += "?" + "&".join(params)
+    
+    versions_data = api_do_request(url)
+    
+    if versions_data is None:
+        return None
+    
+    if isinstance(versions_data, dict) and "error" in versions_data:
+        rich_print_error(f"Error getting versions for Modrinth project '{project_id}': {versions_data['error']}")
+        return None
+        
+    return versions_data
+
+
+def get_modrinth_plugin_version(project_id: str, featured_only: bool = False, version_type: str = None) -> str:
+    """
+    Gets the latest plugin version from Modrinth
+    
+    :param project_id: Modrinth project ID or slug
+    :param featured_only: Only consider featured versions
+    :param version_type: Filter by version type (release, beta, alpha)
+    :returns: Latest version string or None if failed
+    """
+    versions = get_modrinth_versions(project_id, featured_only, version_type)
+    if not versions:
+        return None
+    
+    # Versions are returned sorted by date, newest first
+    latest_version = versions[0]
+    return latest_version.get("version_number", "")
+
+
+def get_modrinth_download_url(project_id: str, featured_only: bool = False, version_type: str = None) -> tuple:
+    """
+    Gets the download URL for the latest Modrinth version
+    
+    :param project_id: Modrinth project ID or slug  
+    :param featured_only: Only consider featured versions
+    :param version_type: Filter by version type (release, beta, alpha)
+    :returns: Tuple of (download_url, filename) or (None, None) if failed
+    """
+    versions = get_modrinth_versions(project_id, featured_only, version_type)
+    if not versions:
+        return None, None
+    
+    latest_version = versions[0]
+    files = latest_version.get("files", [])
+    
+    if not files:
+        rich_print_error(f"Error: No files found in latest version for '{project_id}'!")
+        return None, None
+    
+    # Look for primary file first, then any .jar file
+    for file_info in files:
+        if file_info.get("primary", False):
+            return file_info["url"], file_info["filename"]
+    
+    for file_info in files:
+        if file_info["filename"].endswith(".jar"):
+            return file_info["url"], file_info["filename"]
+    
+    # If no .jar found, return first file
+    return files[0]["url"], files[0]["filename"]
+
+
+def download_modrinth_plugin(project_id: str, featured_only: bool = False, version_type: str = None) -> None:
+    """
+    Downloads the latest plugin version from Modrinth
+    
+    :param project_id: Modrinth project ID or slug
+    :param featured_only: Only consider featured versions  
+    :param version_type: Filter by version type (release, beta, alpha)
+    :returns: None
+    """
+    config_values = config_value()
+    download_url, filename = get_modrinth_download_url(project_id, featured_only, version_type)
+    
+    if download_url is None:
+        return None
+    
+    # Get project info for proper naming
+    project_info = get_modrinth_project_info(project_id)
+    if project_info is None:
+        plugin_name = project_id  # Fallback to project_id
+    else:
+        plugin_name = project_info.get("title", project_id)
+    
+    version = get_modrinth_plugin_version(project_id, featured_only, version_type)
+    if version is None:
+        version = "latest"
+    
+    # Create download path similar to other implementations
+    download_path = get_download_path(config_values)
+    # Use original filename if available, otherwise construct one
+    if filename:
+        plugin_download_name = filename
+    else:
+        plugin_download_name = f"{plugin_name}-{version}.jar"
+    
+    download_plugin_path = Path(f"{download_path}/{plugin_download_name}")
+    
+    # Use existing download infrastructure but with Modrinth URL
+    _download_modrinth_file(download_url, download_plugin_path)
+    
+    return None
+
+
+def _download_modrinth_file(url: str, download_path: Path) -> None:
+    """
+    Downloads a file from Modrinth - similar to GitHub download function
+    
+    :param url: Modrinth file download URL
+    :param download_path: Path where to save the file
+    :returns: None
+    """
+    import os
+    import requests
+    from zipfile import ZipFile
+    from rich.console import Console
+    from rich.progress import Progress
+    from src.utils.utilities import convert_file_size_down, remove_temp_plugin_folder
+    from src.handlers.handle_sftp import sftp_create_connection, sftp_upload_file
+    from src.handlers.handle_ftp import ftp_create_connection, ftp_upload_file
+    
+    config_values = config_value()
+    
+    # Use rich Progress() to create progress bar (same as existing implementations)
+    with Progress(transient=True) as progress:
+        header = {'user-agent': 'pluGET/1.0'}
+        r = requests.get(url, headers=header, stream=True)
+        try:
+            file_size = int(r.headers.get('content-length'))
+            # create progress bar
+            download_task = progress.add_task("    [cyan]Downloading...", total=file_size)
+        except TypeError:
+            # Content-length returned nothing
+            file_size = 0
+        with open(download_path, 'wb') as f:
+            # split downloaded data in chunks of 32768
+            for data in r.iter_content(chunk_size=32768):
+                f.write(data)
+                # don't show progress bar if no content-length was returned
+                if file_size == 0:
+                    continue
+                progress.update(download_task, advance=len(data))
+
+    # use rich console for nice colors (consistent with existing style)
+    console = Console()
+    if file_size == 0:
+        console.print(
+            f"    [not bold][bright_green]Downloaded[bright_magenta]         file [cyan]→ [white]{download_path}"
+        )
+    elif file_size >= 1000000:
+        file_size_data = convert_file_size_down(convert_file_size_down(file_size))
+        console.print("    [not bold][bright_green]Downloaded[bright_magenta] " + (str(file_size_data)).rjust(9) + \
+             f" MB [cyan]→ [white]{download_path}")
+    else:
+        file_size_data = convert_file_size_down(file_size)
+        console.print("    [not bold][bright_green]Downloaded[bright_magenta] " + (str(file_size_data)).rjust(9) + \
+             f" KB [cyan]→ [white]{download_path}")
+
+    # check if plugin file is a proper .jar-file (same validation as existing code)
+    try:
+        with ZipFile(download_path, "r") as plugin_jar:
+            plugin_jar.open("plugin.yml", "r")
+    except:
+        rich_print_error("Error: Downloaded plugin file was not a proper jar-file!")
+        rich_print_error("Removing file...")
+        os.remove(download_path)
+        return None
+
+    # Handle SFTP/FTP upload same as existing implementations
+    if config_values.connection == "sftp":
+        sftp_session = sftp_create_connection()
+        sftp_upload_file(sftp_session, download_path)
+    elif config_values.connection == "ftp":
+        ftp_session = ftp_create_connection()
+        ftp_upload_file(ftp_session, download_path)
+
+    # remove temp plugin folder if plugin was downloaded from sftp/ftp server
+    if config_values.connection != "local":
+        remove_temp_plugin_folder()
+
+    return None
+
+
+def search_modrinth_plugin(search_term: str) -> None:
+    """
+    Search for plugins on Modrinth
+    
+    :param search_term: Search query
+    :returns: None
+    """
+    from rich.table import Table
+    from rich.console import Console
+    
+    # Modrinth search API with filters for plugins
+    url = f"https://api.modrinth.com/v2/search?query={search_term}&facets=[[%22categories:bukkit%22],[%22categories:spigot%22],[%22categories:paper%22]]&sort=downloads"
+    search_results = api_do_request(url)
+    
+    if search_results is None:
+        rich_print_error("Error: Modrinth search request failed!")
+        return None
+    
+    hits = search_results.get("hits", [])
+    if not hits:
+        rich_print_error(f"No plugins found for '{search_term}' on Modrinth")
+        return None
+    
+    # Limit to top 10 results
+    hits = hits[:10]
+    
+    print(f"Searching Modrinth for '{search_term}'...")
+    print(f"Found plugins:")
+    
+    # Create table with rich (same style as existing search functions)
+    rich_table = Table(box=None)
+    rich_table.add_column("No.", justify="right", style="cyan", no_wrap=True)
+    rich_table.add_column("Name", style="bright_magenta")
+    rich_table.add_column("Downloads", justify="right", style="bright_green")
+    rich_table.add_column("Description", justify="left", style="white")
+    
+    # Start counting at 1 for consistency with existing code
+    i = 1
+    for plugin in hits:
+        plugin_name = plugin["title"]
+        downloads = plugin.get("downloads", 0)
+        description = plugin.get("description", "No description") or "No description"
+        # Truncate long descriptions
+        if len(description) > 50:
+            description = description[:47] + "..."
+        rich_table.add_row(str(i), plugin_name, str(downloads), description)
+        i += 1
+
+    # Print table from rich
+    rich_console = Console()
+    rich_console.print(rich_table)
+
+    try:
+        plugin_selected = input("Select your wanted plugin (No.)(0 to exit): ")
+    except KeyboardInterrupt:
+        return None
+    if plugin_selected == "0":
+        return None
+    try:
+        plugin_selected = int(plugin_selected) - 1
+        selected_plugin = hits[plugin_selected]
+    except ValueError:
+        rich_print_error("Error: Input wasn't a number! Please try again!")
+        return None
+    except IndexError:
+        rich_print_error("Error: Number was out of range! Please try again!")
+        return None
+        
+    selected_plugin_name = selected_plugin["title"]
+    selected_project_id = selected_plugin["project_id"]
+    rich_console.print(f"\n [not bold][bright_white]● [bright_magenta]{selected_plugin_name} [bright_green]latest")
+    download_modrinth_plugin(selected_project_id)
+
+    return None
+
+
+def get_modrinth_project_from_plugin_hash(plugin_file_path: str) -> str:
+    """
+    Try to identify a Modrinth project from a plugin file hash
+    This mimics the PluginUpdater approach of using file hashes
+    
+    :param plugin_file_path: Path to the plugin .jar file
+    :returns: Project ID if found, None otherwise
+    """
+    import hashlib
+    
+    try:
+        with open(plugin_file_path, 'rb') as f:
+            file_data = f.read()
+            file_hash = hashlib.sha512(file_data).hexdigest()
+    except (FileNotFoundError, OSError):
+        return None
+    
+    # Use Modrinth's version_files endpoint to lookup by hash
+    url = "https://api.modrinth.com/v2/version_files"
+    payload = {
+        "algorithm": "sha512",
+        "hashes": [file_hash]
+    }
+    
+    # Need to make a POST request for hash lookup
+    import requests
+    import json
+    
+    try:
+        response = requests.post(url, 
+                               json=payload,
+                               headers={'user-agent': 'pluGET/1.0', 'Content-Type': 'application/json'})
+        if response.status_code == 200:
+            result = response.json()
+            if file_hash in result:
+                version_info = result[file_hash]
+                return version_info.get("project_id")
+    except (requests.RequestException, json.JSONDecodeError):
+        pass
+    
+    return None

--- a/src/utils/utilities.py
+++ b/src/utils/utilities.py
@@ -44,9 +44,13 @@ def get_command_help(command: str) -> None:
             rich_table.add_row(
                 "get-waterfall", "WaterfallVersion", "McVersion", "Downloads a specific waterfall version"
             )
+            rich_table.add_row("get-github", "owner/repo", "plugin-name", "Downloads latest plugin from GitHub releases")
+            rich_table.add_row("get-modrinth", "project-id", "featured", "Downloads latest plugin from Modrinth")
             rich_table.add_row("help", "./anything", None, "Get specific help to the commands of pluGET")
             rich_table.add_row("remove", "Name", None, "Delete an installed plugin from the plugin folder")
             rich_table.add_row("search", "Name/all", None, "Search for a plugin and download the latest version")
+            rich_table.add_row("search-github", "Name", None, "Search GitHub for plugins and download")
+            rich_table.add_row("search-modrinth", "Name", None, "Search Modrinth for plugins and download")
             rich_table.add_row("update", "Name/all", None, "Update installed plugins to the latest version")
             rich_table.add_row("update", "serverjar", None, "Update the installed serverjar to the latest version")
         case "check":
@@ -66,6 +70,14 @@ def get_command_help(command: str) -> None:
             rich_table.add_row(
                 "get-waterfall", "WaterfallVersion", "McVersion", "Downloads a specific Waterfall version"
             )
+        case "get-github":
+            rich_table.add_row("get-github", "owner/repo", "plugin-name", "Downloads latest plugin from GitHub releases")
+        case "get-modrinth":
+            rich_table.add_row("get-modrinth", "project-id", "featured", "Downloads latest plugin from Modrinth")
+        case "search-github":
+            rich_table.add_row("search-github", "Name", None, "Search GitHub for plugins and download")
+        case "search-modrinth":
+            rich_table.add_row("search-modrinth", "Name", None, "Search Modrinth for plugins and download")
         case "help" | "all":
             rich_table.add_row("help", "./anything", None, "Get specific help to the commands of pluGET")
         case "remove":


### PR DESCRIPTION
# Add GitHub & Modrinth support

Adds support for downloading and updating plugins from GitHub releases and Modrinth, in addition to the existing SpigotMC support.

## What's new
- `get-github owner/repo` - Download from GitHub releases
- `get-modrinth project-id` - Download from Modrinth  
- `search-github` and `search-modrinth` commands
- Automatic platform detection when checking for updates

## How it works
When you run `check all` or `update all`, pluGET now tries:
1. SpigotMC (existing)
2. Modrinth (file hash matching - very accurate)
3. GitHub (name matching)

<img width="924" height="284" alt="image" src="https://github.com/user-attachments/assets/a92c18d0-7253-40fd-af72-e611d9b449c6" />

Don't be surprised—I used dev builds for some plugins that are unstable, so it upgraded/downgraded to the latest stable version. Everything works as it should. In addition, since WorldGuardExtraFlags was discontinued, it took the Reborn version, which is actively maintained and therefore smarter. Enjoy!

## Files added
- `src/platforms/github_handler.py`
- `src/platforms/modrinth_handler.py` 
- Updated existing files to integrate the new platforms

No breaking changes - everything works exactly like before, just with more plugin sources available.