### PR TITLE
Fix: Update version constant to 1.8.2

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -5,4 +5,4 @@ PLUGETVERSION = current version of pluGET
 """
 
 # constant values
-PLUGETVERSION = "1.8.0"
+PLUGETVERSION = "1.8.2"


### PR DESCRIPTION
Small error from developer's end, version hardcoded was 1.8.0, not 1.8.2, prompting users to update their pluGET instance, when they were already in their latest version